### PR TITLE
chore: Adding required gradle.property keys.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,12 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# variables required to allow build.gradle to parse,
+# override in ~/.gradle/gradle.properties
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+
+sonatypeUsername=
+sonatypePassword=


### PR DESCRIPTION
This should fix unit tests that are currently breaking as the build process requires these gradle.property keys.
