### PR TITLE
fix: Silently catch exceptions from offer when channel is closed.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ on:
   repository_dispatch:
     types: [test]
   pull_request:
-    branches: ['*']
     branches-ignore:
       - 'gh-pages'
 

--- a/places-ktx/src/main/java/com/google/android/libraries/places/ktx/widget/AutocompleteSupportFragment.kt
+++ b/places-ktx/src/main/java/com/google/android/libraries/places/ktx/widget/AutocompleteSupportFragment.kt
@@ -19,6 +19,7 @@ import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -29,16 +30,23 @@ data class PlaceSelectionSuccess(val place: Place) : PlaceSelectionResult()
 
 data class PlaceSelectionError(val status: Status) : PlaceSelectionResult()
 
+// Since offer() can throw when the channel is closed (channel can close before the
+// block within awaitClose), wrap `offer` calls inside `runCatching`.
+// See: https://github.com/Kotlin/kotlinx.coroutines/issues/974
+private fun <E> SendChannel<E>.offerCatching(element: E): Boolean {
+    return runCatching { offer(element) }.getOrDefault(false)
+}
+
 @ExperimentalCoroutinesApi
 fun AutocompleteSupportFragment.placeSelectionEvents() : Flow<PlaceSelectionResult> =
     callbackFlow {
         this@placeSelectionEvents.setOnPlaceSelectedListener(object : PlaceSelectionListener {
             override fun onPlaceSelected(place: Place) {
-                offer(PlaceSelectionSuccess(place))
+                offerCatching(PlaceSelectionSuccess(place))
             }
 
             override fun onError(status: Status) {
-                offer(PlaceSelectionError(status))
+                offerCatching(PlaceSelectionError(status))
             }
         })
         awaitClose { this@placeSelectionEvents.setOnPlaceSelectedListener(null) }


### PR DESCRIPTION
Similar to https://github.com/googlemaps/android-maps-ktx/pull/86
