### PR TITLE
feat: Support bidirectional cancellation for await* calls

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,13 +23,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion versions.android.compileSdk
-    buildToolsVersion versions.android.buildTools
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.google.maps.android.ktx.demo"
-        minSdkVersion versions.android.minSdk
-        targetSdkVersion versions.android.targetSdk
+        minSdkVersion 16
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }
@@ -53,19 +52,19 @@ android {
 }
 
 dependencies {
-    implementation deps.androidx.appcompat
-    implementation deps.androidx.coreKtx
-    implementation deps.kotlin
-    implementation deps.places
-    implementation deps.playServices.maps
+    implementation "androidx.appcompat:appcompat:1.3.0"
+    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.21"
+    api "com.google.android.libraries.places:places:2.4.0"
+    implementation "com.google.android.gms:play-services-maps:17.0.1"
     implementation "androidx.fragment:fragment-ktx:1.3.5"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.android.volley:volley:1.2.0'
 
     // Hilt
-    implementation deps.hilt.android
-    kapt deps.hilt.androidCompiler
+    implementation "com.google.dagger:hilt-android:2.37"
+    kapt "com.google.dagger:hilt-android-compiler:2.37"
 
     implementation project(':places-ktx')
 }

--- a/app/src/main/java/com/google/places/android/ktx/demo/PlacesSearchViewModel.kt
+++ b/app/src/main/java/com/google/places/android/ktx/demo/PlacesSearchViewModel.kt
@@ -27,6 +27,7 @@ import com.google.android.libraries.places.ktx.api.net.awaitFindAutocompletePred
 import com.google.android.libraries.places.ktx.api.net.findAutocompletePredictionsRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -41,6 +42,7 @@ class PlacesSearchViewModel @Inject constructor(
 
     private var searchJob: Job? = null
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun onSearchQueryChanged(query: String) {
         searchJob?.cancel()
 
@@ -60,15 +62,13 @@ class PlacesSearchViewModel @Inject constructor(
                 LatLng(37.808300, -122.391338) // NE lat, lng
             )
 
-            val request = findAutocompletePredictionsRequest {
-                locationBias = bias
-                typeFilter = TypeFilter.ESTABLISHMENT
-                this.query = query
-                countries = listOf("US")
-            }
-
             val response = placesClient
-                .awaitFindAutocompletePredictions(request)
+                .awaitFindAutocompletePredictions {
+                    locationBias = bias
+                    typeFilter = TypeFilter.ESTABLISHMENT
+                    this.query = query
+                    countries = listOf("US")
+                }
 
             _events.value = PlacesSearchEventFound(response.autocompletePredictions)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -15,71 +15,15 @@
  */
 
 buildscript {
-    ext.versions = [
-        'android'          : [
-            "buildTools": "30.0.2",
-            "compileSdk": 30,
-            "minSdk"    : 16,
-            "targetSdk" : 30
-        ],
-        'androidx'         : [
-            'appcompat': '1.1.0',
-            'coreKtx'  : '1.2.0',
-            'espresso' : '3.2.0',
-            'test'     : '1.2.0',
-            'junit'    : '1.1.1',
-        ],
-        'hilt'             : '2.37',
-        'junit'            : '4.12',
-        'kotlin'           : '1.4.32',
-        'kotlinxCoroutines': '1.3.7',
-        'mapsBeta'         : '3.1.0-beta',
-        'mockito'          : '3.0.0',
-        'mockitoKotlin'    : '2.2.0',
-        'places'           : '2.4.0',
-        'playServices'     : '17.0.0',
-    ]
-
-    ext.deps = [
-        'androidx'         : [
-            'appcompat': "androidx.appcompat:appcompat:$versions.androidx.appcompat",
-            'coreKtx'  : "androidx.core:core-ktx:$versions.androidx.coreKtx",
-            'espresso' : "androidx.test.espresso:espresso-core:$versions.androidx.espresso",
-            'test'     : "androidx.test:core:$versions.androidx.test",
-            'junit'    : "androidx.test.ext:junit:$versions.androidx.junit"
-        ],
-        'hilt'             : [
-            'android'          : "com.google.dagger:hilt-android:$versions.hilt",
-            'androidCompiler' : "com.google.dagger:hilt-android-compiler:$versions.hilt",
-        ],
-        'junit'            : "junit:junit:$versions.junit",
-        'kotlin'           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin",
-        'kotlinxCoroutines': [
-            'android':  "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlinxCoroutines",
-            'playServices':  "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$versions.kotlinxCoroutines",
-        ],
-        'mapsBeta'         : "com.google.android.libraries.maps:maps:$versions.mapsBeta",
-        'mockito'          : "org.mockito:mockito-core:$versions.mockito",
-        'mockitoKotlin'    : "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlin",
-        'places'           : "com.google.android.libraries.places:places:$versions.places",
-        'playServices'     : [
-            'basement': "com.google.android.gms:play-services-basement:$versions.playServices",
-            'base'    : "com.google.android.gms:play-services-base:$versions.playServices",
-            'gcm'     : "com.google.android.gms:play-services-gcm:$versions.playServices",
-            'location': "com.google.android.gms:play-services-location:$versions.playServices",
-            'maps'    : "com.google.android.gms:play-services-maps:$versions.playServices",
-        ],
-    ]
-
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$versions.hilt"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.37"
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.3.0"
     }
 }

--- a/places-ktx/build.gradle
+++ b/places-ktx/build.gradle
@@ -19,12 +19,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion versions.android.compileSdk
-    buildToolsVersion versions.android.buildTools
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion versions.android.minSdk
-        targetSdkVersion versions.android.targetSdk
+        minSdkVersion 16
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -41,17 +40,17 @@ android {
 preBuild.dependsOn(rootProject.tasks.copyGmsToV3Beta)
 
 dependencies {
-    implementation deps.kotlin
-    implementation deps.kotlinxCoroutines.android
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.21"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
     implementation "com.android.volley:volley:1.2.0"
-    api deps.kotlinxCoroutines.playServices
-    api deps.places
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1"
+    api "com.google.android.libraries.places:places:2.4.0"
 
     // Tests
-    testImplementation deps.androidx.test
-    testImplementation deps.androidx.junit
-    testImplementation deps.junit
-    testImplementation deps.mockito
-    testImplementation deps.mockitoKotlin
+    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "androidx.test:core:1.4.0"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.mockito:mockito-core:3.0.0"
 }

--- a/places-ktx/src/main/java/com/google/android/libraries/places/ktx/api/net/PlacesClient.kt
+++ b/places-ktx/src/main/java/com/google/android/libraries/places/ktx/api/net/PlacesClient.kt
@@ -16,6 +16,10 @@ package com.google.android.libraries.places.ktx.api.net
 
 import androidx.annotation.RequiresPermission
 import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.tasks.CancellationToken
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.google.android.libraries.places.api.model.PhotoMetadata
+import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.net.FetchPhotoRequest
 import com.google.android.libraries.places.api.net.FetchPhotoResponse
 import com.google.android.libraries.places.api.net.FetchPlaceRequest
@@ -25,6 +29,8 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.FindCurrentPlaceRequest
 import com.google.android.libraries.places.api.net.FindCurrentPlaceResponse
 import com.google.android.libraries.places.api.net.PlacesClient
+import com.google.android.libraries.places.ktx.api.model.photoMetadata
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -32,26 +38,55 @@ import kotlinx.coroutines.tasks.await
  *
  * Fetches a photo. If an error occurred, an [ApiException] will be thrown.
  */
-public suspend fun PlacesClient.awaitFetchPhoto(request: FetchPhotoRequest): FetchPhotoResponse =
-    this.fetchPhoto(request).await()
+@ExperimentalCoroutinesApi
+public suspend fun PlacesClient.awaitFetchPhoto(
+    photoMetadata: PhotoMetadata,
+    actions: FetchPhotoRequest.Builder.() -> Unit
+): FetchPhotoResponse {
+    val cancellationTokenSource = CancellationTokenSource()
+    val request = FetchPhotoRequest.builder(photoMetadata)
+        .setCancellationToken(cancellationTokenSource.token)
+        .apply(actions)
+        .build()
+    return this.fetchPhoto(request)
+        .await(cancellationTokenSource)
+}
 
 /**
  * Wraps [PlacesClient.fetchPlace] in a suspending function.
  *
  * Fetches the details of a place. If an error occurred, an [ApiException] will be thrown.
  */
-public suspend fun PlacesClient.awaitFetchPlace(request: FetchPlaceRequest): FetchPlaceResponse =
-    this.fetchPlace(request).await()
+@ExperimentalCoroutinesApi
+public suspend fun PlacesClient.awaitFetchPlace(
+    placeId: String,
+    placeFields: List<Place.Field>,
+    actions: FetchPlaceRequest.Builder.() -> Unit
+): FetchPlaceResponse {
+    val cancellationTokenSource = CancellationTokenSource()
+    val request = FetchPlaceRequest.builder(placeId, placeFields)
+        .setCancellationToken(cancellationTokenSource.token)
+        .apply(actions)
+        .build()
+    return this.fetchPlace(request).await(cancellationTokenSource)
+}
 
 /**
  * Wraps [PlacesClient.findAutocompletePredictions] in a suspending function.
  *
  * Fetches autocomplete predictions. If an error occurred, an [ApiException] will be thrown.
  */
+@ExperimentalCoroutinesApi
 public suspend fun PlacesClient.awaitFindAutocompletePredictions(
-    request: FindAutocompletePredictionsRequest
-): FindAutocompletePredictionsResponse =
-    this.findAutocompletePredictions(request).await()
+    actions: FindAutocompletePredictionsRequest.Builder.() -> Unit
+): FindAutocompletePredictionsResponse {
+    val cancellationTokenSource = CancellationTokenSource()
+    val request = FindAutocompletePredictionsRequest.builder()
+        .setCancellationToken(cancellationTokenSource.token)
+        .apply(actions)
+        .build()
+    return this.findAutocompletePredictions(request).await(cancellationTokenSource)
+}
 
 /**
  * Wraps [PlacesClient.findCurrentPlace] in a suspending function.
@@ -63,7 +98,15 @@ public suspend fun PlacesClient.awaitFindAutocompletePredictions(
 @RequiresPermission(
     allOf = ["android.permission.ACCESS_FINE_LOCATION", "android.permission.ACCESS_WIFI_STATE"]
 )
+@ExperimentalCoroutinesApi
 public suspend fun PlacesClient.awaitFindCurrentPlace(
-    request: FindCurrentPlaceRequest
-): FindCurrentPlaceResponse =
-    this.findCurrentPlace(request).await()
+    placeFields: List<Place.Field>,
+    actions: FindCurrentPlaceRequest.Builder.() -> Unit
+): FindCurrentPlaceResponse {
+    val cancellationTokenSource = CancellationTokenSource()
+    val request = FindCurrentPlaceRequest.builder(placeFields)
+        .setCancellationToken(cancellationTokenSource.token)
+        .apply(actions)
+        .build()
+    return this.findCurrentPlace(request).await(cancellationTokenSource)
+}

--- a/places-v3-ktx/build.gradle
+++ b/places-v3-ktx/build.gradle
@@ -2,12 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion versions.android.compileSdk
-    buildToolsVersion versions.android.buildTools
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion versions.android.minSdk
-        targetSdkVersion versions.android.targetSdk
+        minSdkVersion 16
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -22,20 +21,20 @@ android {
 }
 
 dependencies {
-    implementation deps.kotlin
-    implementation deps.kotlinxCoroutines.android
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.21"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
     implementation "com.android.volley:volley:1.2.0"
-    api deps.kotlinxCoroutines.playServices
-    api deps.mapsBeta
-    api deps.playServices.gcm
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.1"
+    api "com.google.android.libraries.maps:maps:3.1.0-beta"
+    api "com.google.android.gms:play-services-gcm:17.0.0"
     api name:'places-maps-sdk-3.1.0-beta', ext:'aar'
     api 'com.google.auto.value:auto-value-annotations:1.7.3'
 
     // Tests
-    testImplementation deps.androidx.test
-    testImplementation deps.androidx.junit
-    testImplementation deps.junit
-    testImplementation deps.mockito
-    testImplementation deps.mockitoKotlin
+    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "androidx.test:core:1.4.0"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.mockito:mockito-core:3.0.0"
 }


### PR DESCRIPTION
Supporting bidirectional cancellation. This change modifies the `PlacesClient#await*` calls such that all await methods on PlacesClient now take in a functional literal receiver of the request builder object rather than fully built requests.

Fixes #42 🦕
