### PR TITLE
chore: AGP 7.0.2 + jacoco.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,15 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.37"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.3.0"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
+        classpath 'com.hiya:jacoco-android:0.2'
     }
 }
 
@@ -62,7 +64,18 @@ subprojects { project ->
     apply plugin: 'com.android.library'
     apply plugin: 'maven-publish'
     apply plugin: 'org.jetbrains.dokka'
+    apply plugin: 'com.hiya.jacoco-android'
     apply plugin: 'signing'
+
+    // Code coverage
+    jacoco {
+        toolVersion = "0.8.7"
+    }
+
+    tasks.withType(Test) {
+        jacoco.includeNoLocationClasses = true
+        jacoco.excludes = ['jdk.internal.*']
+    }
 
     // Documentation
     dokka {

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,12 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.37"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.39"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
+        classpath 'com.hiya:jacoco-android:0.2'
     }
 }
 
@@ -65,7 +66,6 @@ subprojects { project ->
     apply plugin: 'org.jetbrains.dokka'
     apply plugin: 'com.hiya.jacoco-android'
     apply plugin: 'signing'
-    apply plugin: 'com.hiya.jacoco-android'
 
     // Code coverage
     jacoco {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Bumping AGP and adding jacoco since the new synced `test.yml` workflow requires it.