### PR TITLE
docs: Update README to mark standalone lib as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies {
 }
 ```
 
-Alternatively, if you are using the Places standalone library (for use only with Maps v 3.1.0 beta):
+(Deprecated) ~~Alternatively, if you are using the Places standalone library (for use only with Maps v 3.1.0 beta):~~
 
 ```groovy 
 dependencies {


### PR DESCRIPTION
Hello!

Since the Maps v3.1.0 beta SDK has been deprecated for the Play Services backed one,
the README instructions have to be updated accordingly.