### PR TITLE
chore: using auto-merge label

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,9 @@ jobs:
         committer: googlemaps-bot <googlemaps-bot@google.com>
         author: googlemaps-bot <googlemaps-bot@google.com>
         title: 'docs: Update docs'
+        labels: |
+          docs
+          automerge
         body: |
             Updated GitHub pages with latest from `./gradlew dokka`.
         branch: googlemaps-bot/update_gh_pages


### PR DESCRIPTION
This PR will set the PRs coming from the docs.yml workflow as automatically approved for merge, so we don't need to release them manually with each release.