### PR TITLE
chore: migrated new Maven Central URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ subprojects { project ->
         repositories {
             maven {
                 name = "mavencentral"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                 credentials {
                     username sonatypeToken
                     password sonatypeTokenPassword


### PR DESCRIPTION
This draft PR migrates the URL required to push onto the new Maven Central. More information about it:

https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/