### PR TITLE
chore: migrating to vanniktech plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,14 @@ jobs:
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"
-        sed -i -e "s,sonatypeToken=,sonatypeToken=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
+        sed -i -e "s,mavenCentralUsername=,mavenCentralUsername=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
         SONATYPE_TOKEN_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_TOKEN_PASSWORD" | sed -e 's/[\/&]/\\&/g')
-        sed -i -e "s,sonatypeTokenPassword=,sonatypeTokenPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
+        sed -i -e "s,mavenCentralPassword=,mavenCentralPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
         sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
         sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
         sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties
       env:
-        GPG_KEY_ARMOR: "${{ secrets.SYNCED_GPG_KEY_ARMOR }}"
+        GPG_KEY_ARMOR: ${{ secrets.SYNCED_GPG_KEY_ARMOR }}
         GPG_KEY_ID: ${{ secrets.SYNCED_GPG_KEY_ID }}
         GPG_PASSWORD: ${{ secrets.SYNCED_GPG_KEY_PASSWORD }}
         SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}

--- a/.releaserc
+++ b/.releaserc
@@ -15,7 +15,7 @@ plugins:
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"
-      publishCmd: "./gradlew publish --warn --stacktrace"
+      publishCmd: "./gradlew publishToMavenCentral --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:
         - "build.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,9 @@ buildscript {
 
 plugins {
     id "org.jetbrains.dokka" version "1.9.10"
+    id "com.vanniktech.maven.publish" version "0.34.0" apply false
 }
+
 
 
 ext.projectArtifactId = { project ->
@@ -43,9 +45,6 @@ ext.projectArtifactId = { project ->
     }
 }
 
-/**
- * Shared configs across subprojects
- */
 allprojects {
     group = 'com.google.maps.android'
     version = '3.3.1'
@@ -60,9 +59,6 @@ allprojects {
     }
 }
 
-/**
- * Publishing and signing info
- */
 subprojects { project ->
     if (project.ext.artifactId == null) return
 
@@ -70,9 +66,8 @@ subprojects { project ->
     plugins.apply(libs.plugins.mavenPublish.get().pluginId)
     plugins.apply(libs.plugins.dokka.get().pluginId)
     plugins.apply(libs.plugins.jacocoAndroid.get().pluginId)
-    plugins.apply(libs.plugins.signing.get().pluginId)
+    plugins.apply(libs.plugins.vanniktech.get().pluginId)
 
-    // Code coverage
     jacoco {
         toolVersion = "0.8.7"
     }
@@ -82,90 +77,44 @@ subprojects { project ->
         jacoco.excludes = ['jdk.internal.*']
     }
 
-    tasks.register('sourcesJar', Jar) {
-        from android.sourceSets.main.java.source
-        archiveClassifier = "sources"
-    }
+    mavenPublishing {
+        publishToMavenCentral()
+        signAllPublications()
 
-    tasks.register('javadocJar', Jar) {
-        dependsOn(tasks.named("dokkaHtml"))
-        dependsOn(tasks.named("dokkaJavadoc"))
-        archiveClassifier.set("javadoc")
-        from new File(buildDir, "dokka/javadoc")
-    }
+        pom {
+            name = project.name
+            description = "Kotlin extensions (KTX) for Places SDK for Android"
+            url = "https://github.com/googlemaps/android-places-ktx"
 
-    publishing {
-        publications {
-            aar(MavenPublication) {
-                groupId project.group
-                artifactId project.ext.artifactId
-                version project.version
-
-                pom {
-                    name = project.name
-                    description = "Kotlin extensions (KTX) for Places SDK for Android"
-                    url = "https://github.com/googlemaps/android-places-ktx"
-                    scm {
-                        connection = 'scm:git@github.com:googlemaps/android-places-ktx.git'
-                        developerConnection = 'scm:git@github.com:googlemaps/android-places-ktx.git'
-                        url = 'https://github.com/googlemaps/android-places-ktx'
-                    }
-
-                    licenses {
-                        license {
-                            name = 'The Apache Software License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                            distribution = 'repo'
-                        }
-                    }
-
-                    organization {
-                        name = 'Google Inc'
-                        url = 'http://developers.google.com/maps'
-                    }
-
-                    developers {
-                        developer {
-                            name = 'Google Inc.'
-                        }
-                    }
+            licenses {
+                license {
+                    name = "The Apache Software License, Version 2.0"
+                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    distribution = "repo"
                 }
+            }
 
-                pom.withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-                    project.configurations.api.allDependencies.each { dependency ->
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', dependency.group)
-                        dependencyNode.appendNode('artifactId', dependency.name)
-                        dependencyNode.appendNode('version', dependency.version)
-                    }
-                }
+            scm {
+                connection = "scm:git@github.com:googlemaps/android-places-ktx.git"
+                developerConnection = "scm:git@github.com:googlemaps/android-places-ktx.git"
+                url = "https://github.com/googlemaps/android-places-ktx"
+            }
 
-                afterEvaluate {
-                    artifact "$buildDir/outputs/aar/$project.name-release.aar"
-                    artifact javadocJar
-                    artifact sourcesJar
+            organization {
+                name = "Google Inc"
+                url = "http://developers.google.com/maps"
+            }
+
+            developers {
+                developer {
+                    id = "google"
+                    name = "Google Inc."
                 }
             }
         }
-
-        repositories {
-            maven {
-                name = "mavencentral"
-                url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
-                credentials {
-                    username sonatypeToken
-                    password sonatypeTokenPassword
-                }
-            }
-        }
-    }
-
-    signing {
-        sign publishing.publications.aar
     }
 }
 
-tasks.register('clean', Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.layout.buildDirectory
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,9 +26,6 @@ signing.keyId=
 signing.password=
 signing.secretKeyRingFile=
 
-sonatypeToken=
-sonatypeTokenPassword=
-
 mavenCentralUsername=
 mavenCentralPassword=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,10 @@ signing.secretKeyRingFile=
 
 sonatypeToken=
 sonatypeTokenPassword=
+
+mavenCentralUsername=
+mavenCentralPassword=
+
+# Add a property to enable automatic release to Maven Central (optional, but good for CI)
+# If true, publishToMavenCentral will also close and release the staging repository
+mavenCentralAutomaticRelease=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ test-core = "1.6.1"
 mockito-kotlin = "2.2.0"
 junit = "4.13.2"
 mockito-core = "5.11.0"
+gradleMavenPublishPlugin = "0.34.0"
 
 [libraries]
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -55,6 +56,7 @@ test-core = { group = "androidx.test", name = "core", version.ref = "test-core" 
 mockito-kotlin = { group = "com.nhaarman.mockitokotlin2", name = "mockito-kotlin", version.ref = "mockito-kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito-core" }
+gradle-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradleMavenPublishPlugin" }
 
 [plugins]
 androidLibrary = { id = "com.android.library" }
@@ -62,3 +64,4 @@ mavenPublish = { id = "maven-publish" }
 dokka = { id = "org.jetbrains.dokka" }
 jacocoAndroid = { id = "com.mxalbert.gradle.jacoco-android" }
 signing = { id = "signing" }
+vanniktech = { id = "com.vanniktech.maven.publish" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'
 include ':places-ktx'
 rootProject.name = "android-places-ktx"


### PR DESCRIPTION
The following PR migrates from the maven-publish plugin to vanniktech, to support the new Maven Central.

This PR provides the new configuration and data we need (including the maven central username and password). Note that the migration here is a bit different, since we don't have a Convention Plugin.