### PR TITLE
build: run lint only on PRs

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -15,9 +15,6 @@
 name: Lint and Upload SARIF
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This PR modifies the build to run the Lint report only on PRs (we don't need it on every push, for what we would need to add a new permission)

BREAKING CHANGE:  triggers a new release for the 5.0.0 places SDK